### PR TITLE
problem with gem versions during installation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 
 gem 'rails', '3.0.4'
 
-gem 'mysql2'
+gem 'mysql2', '~> 0.2.7'
 
 gem 'haml'
 


### PR DESCRIPTION
getting problem when trying 'gem install activerecord-mysql2-adapter' -- specifying version for mysql2 gem fixes problem
