### PR TITLE
fixed 'uninitialized constant Basepack' error with netzke 0.7.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,5 +18,6 @@ gem 'carrierwave'
 gem 'inploy'
 
 group :profiling do
-  gem 'rack-perftools_profiler', '~> 0.1', :require => 'rack/perftools_profiler'
+#  gem 'rack-perftools_profiler', '~> 0.1', :require => 'rack/perftools_profiler'
+  gem 'rack-perftools_profiler', :require => 'rack/perftools_profiler'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,19 @@
 PATH
   remote: vendor/gems/netzke-basepack
   specs:
-    netzke-basepack (0.7.0)
-      acts_as_list (~> 0.1.4)
-      meta_where (~> 1.0.0)
-      netzke-core (~> 0.7.0)
-      will_paginate (~> 3.0.0)
+    netzke-basepack (0.7.6)
+      netzke-core (~> 0.7.6)
 
 PATH
   remote: vendor/gems/netzke-core
   specs:
-    netzke-core (0.7.1)
-      activesupport (~> 3.0.0)
+    netzke-core (0.7.6)
+      activesupport (>= 3.0.0)
 
 PATH
   remote: vendor/gems/netzke-persistence
   specs:
-    netzke-persistence (0.2.0)
+    netzke-persistence (0.1.1)
 
 GEM
   remote: http://rubygems.org/
@@ -48,39 +45,35 @@ GEM
       activemodel (= 3.0.9)
       activesupport (= 3.0.9)
     activesupport (3.0.9)
-    acts_as_list (0.1.4)
     arel (2.0.10)
     builder (2.1.2)
-    carrierwave (0.5.6)
+    carrierwave (0.5.8)
       activesupport (~> 3.0)
-    coderay (0.9.8)
+    coderay (1.0.7)
     erubis (2.6.6)
       abstract (>= 1.0.0)
-    faker (0.9.5)
+    faker (1.0.1)
       i18n (~> 0.4)
-    haml (3.1.2)
+    haml (3.1.6)
     i18n (0.5.0)
-    inploy (1.9.3)
+    inploy (1.9.5)
+    json (1.7.4)
     mail (2.2.19)
       activesupport (>= 2.3.6)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    meta_where (1.0.4)
-      activerecord (~> 3.0.0)
-      activesupport (~> 3.0.0)
-      arel (~> 2.0.7)
-    mime-types (1.16)
-    mysql2 (0.2.11)
-    open4 (1.1.0)
-    perftools.rb (0.5.6)
-    polyglot (0.3.2)
-    rack (1.2.3)
+    mime-types (1.19)
+    mysql2 (0.2.18)
+    open4 (1.3.0)
+    perftools.rb (2.0.0)
+    polyglot (0.3.3)
+    rack (1.2.5)
     rack-mount (0.6.14)
       rack (>= 1.0.0)
-    rack-perftools_profiler (0.5.0)
+    rack-perftools_profiler (0.6.0)
       open4 (~> 1.0)
-      perftools.rb (~> 0.5.6)
+      perftools.rb (~> 2.0.0)
       rack (~> 1.0)
     rack-test (0.5.7)
       rack (>= 1.0)
@@ -98,14 +91,14 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (~> 0.14.4)
-    rake (0.9.2)
-    rdoc (3.9.1)
+    rake (0.9.2.2)
+    rdoc (3.12)
+      json (~> 1.4)
     thor (0.14.6)
     treetop (1.4.10)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.29)
-    will_paginate (3.0.0)
+    tzinfo (0.3.33)
 
 PLATFORMS
   ruby
@@ -120,5 +113,5 @@ DEPENDENCIES
   netzke-basepack!
   netzke-core!
   netzke-persistence!
-  rack-perftools_profiler (~> 0.1)
+  rack-perftools_profiler
   rails (= 3.0.9)

--- a/app/components/bosses_and_clerks.rb
+++ b/app/components/bosses_and_clerks.rb
@@ -48,7 +48,7 @@ class BossesAndClerks < Netzke::Basepack::BorderLayoutPanel
 
   component :bosses do
     {
-      :class_name => "Basepack::GridPanel",
+      :class_name => "Netzke::Basepack::GridPanel",
       :model => "Boss"
     }
   end

--- a/app/components/some_simple_app.rb
+++ b/app/components/some_simple_app.rb
@@ -109,14 +109,14 @@ class SomeSimpleApp < Netzke::Basepack::SimpleApp
 
   # Components
   component :bosses,
-    :class_name => "Basepack::GridPanel",
+    :class_name => "Netzke::Basepack::GridPanel",
     :model => "Boss",
     :lazy_loading => true,
     :title => "Bosses",
     :persistence => true
 
   component :clerks,
-    :class_name => "Basepack::GridPanel",
+    :class_name => "Netzke::Basepack::GridPanel",
     :model => "Clerk",
     :lazy_loading => true,
     :title => "Clerks",
@@ -157,7 +157,7 @@ class SomeSimpleApp < Netzke::Basepack::SimpleApp
 
   # A simple panel thit will render a page with links to different Rails views that have embedded widgets in them
   component :embedded,
-    :class_name => "Basepack::Panel",
+    :class_name => "Netzke::Basepack::Panel",
     :auto_load => "demo/embedded",
     :body_padding => 15,
     :title => "Components embedded into Rails views",

--- a/app/views/accordion_panel/index.html.erb
+++ b/app/views/accordion_panel/index.html.erb
@@ -10,13 +10,13 @@
 <h2>Example 1: an accordion with two GridPanels as panels</h2>
 <p>An accordion with 2 panels, each containing a (preloaded) GridPanel.</p>
 <%= netzke :two_grid_panels,
-            :class_name => "Basepack::AccordionPanel",
+            :class_name => "Netzke::Basepack::AccordionPanel",
             :items => [{
-              :class_name => "Basepack::GridPanel",
+              :class_name => "Netzke::Basepack::GridPanel",
               :model => "Boss",
               :title => "Bosses"
             },{
-              :class_name => "Basepack::GridPanel",
+              :class_name => "Netzke::Basepack::GridPanel",
               :model => "Clerk",
               :title => "Clerks"
             }],
@@ -28,13 +28,13 @@
 <h2>Example 2: second GridPanel loads dynamically</h2>
 <p>Same as before, but the second grid gets first loaded at the moment its tab panel gets expanded.</p>
 <%= netzke :with_dynamic_loading,
-  :class_name => "Basepack::AccordionPanel",
+  :class_name => "Netzke::Basepack::AccordionPanel",
   :items => [{
-    :class_name => "Basepack::GridPanel",
+    :class_name => "Netzke::Basepack::GridPanel",
     :model => "Boss",
     :title => "Bosses"
   },{
-    :class_name => "Basepack::GridPanel",
+    :class_name => "Netzke::Basepack::GridPanel",
     :model => "Clerk",
     :title => "Clerks",
     :lazy_loading => true # this is what makes a component load dynamically
@@ -48,26 +48,26 @@
 <p>The first panel is a simple Ext.Panel. The second panel is a BorderLayoutPanel with two nested Netzke components - a grid and a form</p>
 
 <%= netzke :border_layout_panel_active,
-  :class_name => "Basepack::AccordionPanel",
+  :class_name => "Netzke::Basepack::AccordionPanel",
   :items => [{
     :html => "Some content",
     :title => "A simple Ext panel"
   },{
-    :class_name => "Basepack::BorderLayoutPanel",
+    :class_name => "Netzke::Basepack::BorderLayoutPanel",
     :title => "A compound component",
     :header => false,
     :lazy_loading => true,
     :items => [{
       :region => :center,
       :title => "A grid",
-      :class_name => "Basepack::GridPanel",
+      :class_name => "Netzke::Basepack::GridPanel",
       :model => "Boss",
       :columns => [:name, :salary]
     },{
       :region => :east,
       :title => "A form",
       :split => true,
-      :class_name => "Basepack::FormPanel",
+      :class_name => "Netzke::Basepack::FormPanel",
       :model => "Clerk",
       :record_id => Clerk.first.id,
       :width => 350

--- a/app/views/demo/embedded.haml
+++ b/app/views/demo/embedded.haml
@@ -3,7 +3,7 @@ It's possible to embed Netzke components straight into Rails views. Here are som
 %h2 GridPanel
 
 %p
-  Basepack::GridPanel is the most powerful and most used component of Netzke::Basepack.
+  Netzke::Basepack::GridPanel is the most powerful and most used component of Netzke::Basepack.
   %br
   = new_window_link_to "Demo/tutorial", :controller => "grid_panel"
   \.

--- a/app/views/grid_panel/index.html.erb
+++ b/app/views/grid_panel/index.html.erb
@@ -18,20 +18,20 @@
 <p>Code (in the view):</p>
 <% coderay do %>
 netzke :bosses,
-  :class_name => "Basepack::GridPanel",
+  :class_name => "Netzke::Basepack::GridPanel",
   :model => 'Boss'
 <% end %>
 
 <p>Result:</p>
 <%= netzke :bosses,
-  :class_name => "Basepack::GridPanel",
+  :class_name => "Netzke::Basepack::GridPanel",
   :model => 'Boss' %>
 
 <h2>Control over columns</h2>
 <p>If you need more control over which columns to display and how, you can provide <tt>:columns</tt> option:</p>
 <% coderay do %>
 netzke :bosses_custom_columns,
-  :class_name => "Basepack::GridPanel",
+  :class_name => "Netzke::Basepack::GridPanel",
   :model => 'Boss',
   :title => "Bosses",
   :width => 400,
@@ -42,7 +42,7 @@ netzke :bosses_custom_columns,
 <% end %>
 <p>Result:</p>
 <%= netzke :bosses_custom_columns,
-  :class_name => "Basepack::GridPanel",
+  :class_name => "Netzke::Basepack::GridPanel",
   :model => 'Boss',
   :title => "Bosses",
   :width => 400,
@@ -125,14 +125,14 @@ netzke :clerk_grid
 You can specify which actions are allowed for this grid
 <% coderay do %>
 netzke :bosses_with_permissions,
-  :class_name => "Basepack::GridPanel",
+  :class_name => "Netzke::Basepack::GridPanel",
   :model => 'Boss',
   :prohibit_update => true,
   :prohibit_delete => true
 <% end %>
 <p>Result:</p>
 <%= netzke :bosses_with_permissions,
-  :class_name => "Basepack::GridPanel",
+  :class_name => "Netzke::Basepack::GridPanel",
   :model => 'Boss',
   :prohibit_update => true,
   :prohibit_delete => true
@@ -145,7 +145,7 @@ netzke :bosses_with_permissions,
 
 <% coderay do %>
 netzke :clerks_with_custom_bottom_bar,
-    :class_name => "Basepack::GridPanel",
+    :class_name => "Netzke::Basepack::GridPanel",
     :model => 'Clerk',
     :bbar => nil,
     :tbar => [{
@@ -161,7 +161,7 @@ netzke :clerks_with_custom_bottom_bar,
 
 <p>Result:</p>
 <%= netzke :clerks_with_custom_bottom_bar,
-    :class_name => "Basepack::GridPanel",
+    :class_name => "Netzke::Basepack::GridPanel",
     :model => 'Clerk',
     :bbar => nil,
     :tbar => [{

--- a/app/views/window/index.html.erb
+++ b/app/views/window/index.html.erb
@@ -12,18 +12,18 @@
 
 <input type="button" value="Show window" onClick="Netzke.page.window.show(); Ext.get(this).hide();" />
 
-<%= netzke :window, :class_name => "Basepack::Window", :width => 200, :height => 100, :persistence => true %>
+<%= netzke :window, :class_name => "Netzke::Basepack::Window", :width => 200, :height => 100, :persistence => true %>
 
 <h2>Example 2: a window nesting a GridPanel</h2>
 
 <input type="button" value="Show window" onClick="Netzke.page.windowWithGridPanel.show(); Ext.get(this).hide();" />
 
 <%= netzke :window_with_grid_panel,
-      :class_name => "Basepack::Window",
+      :class_name => "Netzke::Basepack::Window",
       :width => 700, :height => 400,
       :persistence => true,
       :items => [{
-        :class_name => "Basepack::GridPanel",
+        :class_name => "Netzke::Basepack::GridPanel",
         :model => "Boss",
         :header => false, :border => true
       }]
@@ -34,7 +34,7 @@
 <input type="button" value="Show window" onClick="Netzke.page.windowWithBossesAndClerks.show(); Ext.get(this).hide();" />
 
 <%= netzke :window_with_bosses_and_clerks,
-      :class_name => "Basepack::Window",
+      :class_name => "Netzke::Basepack::Window",
       :width => "80%", :height => 600,
       :persistence => true,
       :items => [{
@@ -48,7 +48,7 @@
 
 <input type="button" value="Show window" onClick="Netzke.page.reopenableWindow.show()" />
 <%= netzke :reopenable_window,
-      :class_name => "Basepack::Window",
+      :class_name => "Netzke::Basepack::Window",
       :persistence => true,
       :close_action => "hide",
       :width => 200, :height => 100


### PR DESCRIPTION
With the following config
- ruby 1.9.2, 
- rails 3.0.9,
-  extjs 4.0.7
- Netzke 0.7.6 , 

The server raises an error : uninitialized constant Basepack, so I just prepended Basepack with Netzke::

I could not compile 'rack-perftools_profiler', '~> 0.1' , so I changed the Gemfile to use the latest gem version
which seems to be ok
